### PR TITLE
Enabled the injecting of ApplicationEventPublisher into SAMLProcessingFilter

### DIFF
--- a/spring-boot-security-saml/src/main/java/com/github/ulisesbocchio/spring/boot/security/saml/configuration/SAMLServiceProviderSecurityConfiguration.java
+++ b/spring-boot-security-saml/src/main/java/com/github/ulisesbocchio/spring/boot/security/saml/configuration/SAMLServiceProviderSecurityConfiguration.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
@@ -114,6 +115,9 @@ public class SAMLServiceProviderSecurityConfiguration implements InitializingBea
 
     @Autowired(required = false)
     SAMLConfigurerBean samlConfigurerBean;
+    
+    @Autowired(required = false)
+    ApplicationEventPublisher eventPublisher;
 
     @Autowired
     ServiceProviderBuilder serviceProviderBuilder;
@@ -235,6 +239,7 @@ public class SAMLServiceProviderSecurityConfiguration implements InitializingBea
         serviceProviderBuilder.setSharedObject(WebSSOProfileConsumer.class, webSSOProfileConsumer);
         serviceProviderBuilder.setSharedObject(WebSSOProfileConsumerHoKImpl.class, hokWebSSOProfileConsumer);
         serviceProviderBuilder.setSharedObject(SAMLLogger.class, samlLogger);
+        serviceProviderBuilder.setSharedObject(ApplicationEventPublisher.class, eventPublisher);
     }
 
 }

--- a/spring-boot-security-saml/src/main/java/com/github/ulisesbocchio/spring/boot/security/saml/configurer/builder/SSOConfigurer.java
+++ b/spring-boot-security-saml/src/main/java/com/github/ulisesbocchio/spring/boot/security/saml/configurer/builder/SSOConfigurer.java
@@ -5,6 +5,7 @@ import com.github.ulisesbocchio.spring.boot.security.saml.configurer.ServiceProv
 import com.github.ulisesbocchio.spring.boot.security.saml.properties.SAMLSSOProperties;
 import com.github.ulisesbocchio.spring.boot.security.saml.properties.WebSSOProfileOptionProperties;
 import org.assertj.core.util.VisibleForTesting;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
 import org.springframework.security.saml.SAMLDiscovery;
@@ -76,12 +77,14 @@ public class SSOConfigurer extends SecurityConfigurerAdapter<Void, ServiceProvid
     private ServiceProviderEndpoints endpoints;
     private String ssoHoKProcessingURL;
     private SAMLEntryPoint samlEntryPointBean;
+    private ApplicationEventPublisher eventPublisher;
 
     @Override
     public void init(ServiceProviderBuilder builder) throws Exception {
         authenticationManager = builder.getSharedObject(AuthenticationManager.class);
         config = builder.getSharedObject(SAMLSSOProperties.class);
         endpoints = builder.getSharedObject(ServiceProviderEndpoints.class);
+        eventPublisher = builder.getSharedObject(ApplicationEventPublisher.class);
     }
 
     @Override
@@ -161,7 +164,9 @@ public class SSOConfigurer extends SecurityConfigurerAdapter<Void, ServiceProvid
 
     @VisibleForTesting
     protected SAMLWebSSOHoKProcessingFilter createDefaultSamlHoKProcessingFilter() {
-        return new SAMLWebSSOHoKProcessingFilter();
+        SAMLWebSSOHoKProcessingFilter filter = new SAMLWebSSOHoKProcessingFilter();
+        filter.setApplicationEventPublisher(eventPublisher);
+        return filter;
     }
 
     @VisibleForTesting
@@ -176,7 +181,9 @@ public class SSOConfigurer extends SecurityConfigurerAdapter<Void, ServiceProvid
 
     @VisibleForTesting
     protected SAMLProcessingFilter createDefaultSamlProcessingFilter() {
-        return new SAMLProcessingFilter();
+        SAMLProcessingFilter filter = new SAMLProcessingFilter();
+        filter.setApplicationEventPublisher(eventPublisher);
+        return filter;
     }
 
     @VisibleForTesting

--- a/spring-boot-security-saml/src/main/java/com/github/ulisesbocchio/spring/boot/security/saml/configurer/builder/SSOConfigurer.java
+++ b/spring-boot-security-saml/src/main/java/com/github/ulisesbocchio/spring/boot/security/saml/configurer/builder/SSOConfigurer.java
@@ -84,7 +84,10 @@ public class SSOConfigurer extends SecurityConfigurerAdapter<Void, ServiceProvid
         authenticationManager = builder.getSharedObject(AuthenticationManager.class);
         config = builder.getSharedObject(SAMLSSOProperties.class);
         endpoints = builder.getSharedObject(ServiceProviderEndpoints.class);
-        eventPublisher = builder.getSharedObject(ApplicationEventPublisher.class);
+        
+        if ( config.isEnableEventPublisher() )
+            eventPublisher = builder.getSharedObject(ApplicationEventPublisher.class);
+        else eventPublisher = null;
     }
 
     @Override

--- a/spring-boot-security-saml/src/main/java/com/github/ulisesbocchio/spring/boot/security/saml/properties/SAMLSSOProperties.java
+++ b/spring-boot-security-saml/src/main/java/com/github/ulisesbocchio/spring/boot/security/saml/properties/SAMLSSOProperties.java
@@ -154,4 +154,9 @@ public class SAMLSSOProperties {
      * The URL that the {@link SAMLEntryPoint} filter will be listening to.
      */
     private String ssoLoginUrl = "saml/login";
+    
+    /**
+     * Enabled the use of {@link ApplicationEventPublisher} for those Beans that support its use (disabled by default)
+     */
+    private boolean enableEventPublisher = false;
 }


### PR DESCRIPTION
The SAMLProcessingFilter extends an Abstract class that implements support for generating AuthenticationSuccessEvents when upon success. This PR adds the logic to have the ApplicationEventPublisher autowired and passed through to the SAMLProcessingFilters instances that are created. 

I wrapped the logic with an enableEventProcessor configuration item to keep things backward compatible. I haven't gone through and see if there are other spring-security-saml beans that should be thus enabled yet either.