### PR TITLE
Don't require fields to be set in DSL* that extends AbstractProfileBase

### DIFF
--- a/spring-boot-security-saml/src/main/java/com/github/ulisesbocchio/spring/boot/security/saml/bean/override/DSLSingleLogoutProfileImpl.java
+++ b/spring-boot-security-saml/src/main/java/com/github/ulisesbocchio/spring/boot/security/saml/bean/override/DSLSingleLogoutProfileImpl.java
@@ -21,4 +21,11 @@ public class DSLSingleLogoutProfileImpl extends SingleLogoutProfileImpl {
     public void setMetadata(MetadataManager metadata) {
         super.setMetadata(metadata);
     }
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		// org.springframework.security.saml.websso.AbstractProfileBase.afterPropertiesSet()
+		// will check that properties are set, which is not desirable here
+		// as that defeats the purpose of the non-required autowire intent of this class.
+	}
 }

--- a/spring-boot-security-saml/src/main/java/com/github/ulisesbocchio/spring/boot/security/saml/bean/override/DSLWebSSOProfileConsumerHoKImpl.java
+++ b/spring-boot-security-saml/src/main/java/com/github/ulisesbocchio/spring/boot/security/saml/bean/override/DSLWebSSOProfileConsumerHoKImpl.java
@@ -21,4 +21,11 @@ public class DSLWebSSOProfileConsumerHoKImpl extends WebSSOProfileConsumerHoKImp
     public void setMetadata(MetadataManager metadata) {
         super.setMetadata(metadata);
     }
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		// org.springframework.security.saml.websso.AbstractProfileBase.afterPropertiesSet()
+		// will check that properties are set, which is not desirable here
+		// as that defeats the purpose of the non-required autowire intent of this class.
+	}
 }

--- a/spring-boot-security-saml/src/main/java/com/github/ulisesbocchio/spring/boot/security/saml/bean/override/DSLWebSSOProfileConsumerImpl.java
+++ b/spring-boot-security-saml/src/main/java/com/github/ulisesbocchio/spring/boot/security/saml/bean/override/DSLWebSSOProfileConsumerImpl.java
@@ -22,4 +22,11 @@ public class DSLWebSSOProfileConsumerImpl extends WebSSOProfileConsumerImpl {
         super.setMetadata(metadata);
     }
 
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		// org.springframework.security.saml.websso.AbstractProfileBase.afterPropertiesSet()
+		// will check that properties are set, which is not desirable here
+		// as that defeats the purpose of the non-required autowire intent of this class.
+	}
+
 }

--- a/spring-boot-security-saml/src/main/java/com/github/ulisesbocchio/spring/boot/security/saml/bean/override/DSLWebSSOProfileECPImpl.java
+++ b/spring-boot-security-saml/src/main/java/com/github/ulisesbocchio/spring/boot/security/saml/bean/override/DSLWebSSOProfileECPImpl.java
@@ -21,4 +21,11 @@ public class DSLWebSSOProfileECPImpl extends WebSSOProfileECPImpl {
     public void setMetadata(MetadataManager metadata) {
         super.setMetadata(metadata);
     }
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		// org.springframework.security.saml.websso.AbstractProfileBase.afterPropertiesSet()
+		// will check that properties are set, which is not desirable here
+		// as that defeats the purpose of the non-required autowire intent of this class.
+	}
 }

--- a/spring-boot-security-saml/src/main/java/com/github/ulisesbocchio/spring/boot/security/saml/bean/override/DSLWebSSOProfileHoKImpl.java
+++ b/spring-boot-security-saml/src/main/java/com/github/ulisesbocchio/spring/boot/security/saml/bean/override/DSLWebSSOProfileHoKImpl.java
@@ -21,4 +21,11 @@ public class DSLWebSSOProfileHoKImpl extends WebSSOProfileHoKImpl {
     public void setMetadata(MetadataManager metadata) {
         super.setMetadata(metadata);
     }
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		// org.springframework.security.saml.websso.AbstractProfileBase.afterPropertiesSet()
+		// will check that properties are set, which is not desirable here
+		// as that defeats the purpose of the non-required autowire intent of this class.
+	}
 }

--- a/spring-boot-security-saml/src/main/java/com/github/ulisesbocchio/spring/boot/security/saml/bean/override/DSLWebSSOProfileImpl.java
+++ b/spring-boot-security-saml/src/main/java/com/github/ulisesbocchio/spring/boot/security/saml/bean/override/DSLWebSSOProfileImpl.java
@@ -21,4 +21,11 @@ public class DSLWebSSOProfileImpl extends WebSSOProfileImpl {
     public void setMetadata(MetadataManager metadata) {
         super.setMetadata(metadata);
     }
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		// org.springframework.security.saml.websso.AbstractProfileBase.afterPropertiesSet()
+		// will check that properties are set, which is not desirable here
+		// as that defeats the purpose of the non-required autowire intent of this class.
+	}
 }


### PR DESCRIPTION
AbstractProfileBase.afterPropertiesSet() checks that the fields have been autowired and not requiring autowiring is the point of these classes.