### PR TITLE
entityId should default to null

### DIFF
--- a/docs/properties/config-properties.md
+++ b/docs/properties/config-properties.md
@@ -89,7 +89,7 @@ The following table shows all the available properties (Parsed from Spring Confi
 |saml.sso.metadata-generator.bindings-slo	|null	|List of bindings to be included in the generated metadata for Single Logout. Ordering of bindings affects  inclusion in the generated metadata. Supported values are: "post" (or "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST")  and "redirect" (or "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"). The following bindings are  included  by default: "post", "redirect".	|
 |saml.sso.metadata-generator.bindings-sso	|null	|List of bindings to be included in the generated metadata for Web Single Sign-On. Ordering of bindings  affects inclusion in the generated metadata. Supported values are: "artifact" (or  "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact"), "post" (or "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST")  and "paos" (or "urn:oasis:names:tc:SAML:2.0:bindings:PAOS"). The following bindings are included by default:  "artifact", "post".	|
 |saml.sso.metadata-generator.entity-base-url	|null	|This Service Provider's entity base URL. Provide if base URL cannot be inferred by using the hostname where  the Service Provider will be running. I.E. if running on the cloud behind a load balancer.	|
-|saml.sso.metadata-generator.entity-id	|localhost	|This Service Provider's SAML Entity ID. Used as entity id for generated requests from this Service Provider.	|
+|saml.sso.metadata-generator.entity-id	|null	|This Service Provider's SAML Entity ID. Used as entity id for generated requests from this Service Provider.	|
 |saml.sso.metadata-generator.id	|null	|Local ID. Used as part of Entity Descriptor.	|
 |saml.sso.metadata-generator.include-discovery-extension	|true	|When true discovery profile extension metadata pointing to the default SAMLEntryPoint will be generated and  stored in the generated metadata document.	|
 |saml.sso.metadata-generator.metadata-url	|/saml/metadata	|{@link MetadataDisplayFilter} processing URL. Defines which URL will display the Service Provider Metadata.	|
@@ -245,7 +245,7 @@ saml.sso.metadata-generator.bindings-sso=null
 #This Service Provider's entity base URL. Provide if base URL cannot be inferred by using the hostname where  the Service Provider will be running. I.E. if running on the cloud behind a load balancer.
 saml.sso.metadata-generator.entity-base-url=null
 #This Service Provider's SAML Entity ID. Used as entity id for generated requests from this Service Provider.
-saml.sso.metadata-generator.entity-id=localhost
+saml.sso.metadata-generator.entity-id=null
 #Local ID. Used as part of Entity Descriptor.
 saml.sso.metadata-generator.id=null
 #When true discovery profile extension metadata pointing to the default SAMLEntryPoint will be generated and  stored in the generated metadata document.

--- a/spring-boot-security-saml/src/main/java/com/github/ulisesbocchio/spring/boot/security/saml/properties/MetadataGeneratorProperties.java
+++ b/spring-boot-security-saml/src/main/java/com/github/ulisesbocchio/spring/boot/security/saml/properties/MetadataGeneratorProperties.java
@@ -26,7 +26,7 @@ public class MetadataGeneratorProperties {
     /**
      * This Service Provider's SAML Entity ID. Used as entity id for generated requests from this Service Provider.
      */
-    private String entityId = "localhost";
+    private String entityId = null;
 
     /**
      * Local ID. Used as part of Entity Descriptor.


### PR DESCRIPTION
Having entityId default to "localhost" causes the default configuration of to disagree with the default configuration of Spring Security SAML which is surprising. Leaving it set to null ends up with an entityId of `<entityBaseUrl>/saml/metadata` as expected. See https://docs.spring.io/autorepo/docs/spring-security-saml/1.0.4.RELEASE/reference/html/configuration-metadata.html