### PR TITLE
Bump spring-security-saml2-core to 1.0.9.RELEASE

### DIFF
--- a/spring-boot-security-saml/pom.xml
+++ b/spring-boot-security-saml/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>org.springframework.security.extensions</groupId>
             <artifactId>spring-security-saml2-core</artifactId>
-            <version>1.0.4.RELEASE</version>
+            <version>1.0.9.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
This bump is particular important because it eliminates the dependency on ca.juluisdavis:not-yet-commons-ssl
See https://github.com/spring-projects/spring-security-saml/issues/263