### PR TITLE
Make it possible to configure session authentication strategy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: java
 jdk:
   - oraclejdk8

--- a/spring-boot-security-saml/src/main/java/com/github/ulisesbocchio/spring/boot/security/saml/configurer/builder/SSOConfigurer.java
+++ b/spring-boot-security-saml/src/main/java/com/github/ulisesbocchio/spring/boot/security/saml/configurer/builder/SSOConfigurer.java
@@ -17,6 +17,7 @@ import org.springframework.security.web.authentication.AuthenticationFailureHand
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
 
 import java.util.Optional;
 
@@ -78,6 +79,7 @@ public class SSOConfigurer extends SecurityConfigurerAdapter<Void, ServiceProvid
     private String ssoHoKProcessingURL;
     private SAMLEntryPoint samlEntryPointBean;
     private ApplicationEventPublisher eventPublisher;
+    private SessionAuthenticationStrategy sessionAuthenticationStrategy;
 
     @Override
     public void init(ServiceProviderBuilder builder) throws Exception {
@@ -114,6 +116,9 @@ public class SSOConfigurer extends SecurityConfigurerAdapter<Void, ServiceProvid
         ssoProcessingURL = Optional.ofNullable(ssoProcessingURL).orElseGet(config::getSsoProcessingUrl);
         endpoints.setSsoProcessingURL(ssoProcessingURL);
         ssoFilter.setFilterProcessesUrl(ssoProcessingURL);
+        if (sessionAuthenticationStrategy != null) {
+            ssoFilter.setSessionAuthenticationStrategy(sessionAuthenticationStrategy);
+        }
 
         SAMLWebSSOHoKProcessingFilter ssoHoKFilter = null;
         if (Optional.ofNullable(enableSsoHoK).orElseGet(config::isEnableSsoHok)) {
@@ -124,6 +129,9 @@ public class SSOConfigurer extends SecurityConfigurerAdapter<Void, ServiceProvid
             ssoHoKProcessingURL = Optional.ofNullable(ssoHoKProcessingURL).orElseGet(config::getSsoHokProcessingUrl);
             endpoints.setSsoHoKProcessingURL(ssoHoKProcessingURL);
             ssoHoKFilter.setFilterProcessesUrl(ssoHoKProcessingURL);
+            if (sessionAuthenticationStrategy != null) {
+                ssoHoKFilter.setSessionAuthenticationStrategy(sessionAuthenticationStrategy);
+            }
         }
 
         SAMLDiscovery discoveryFilter = createDefaultSamlDiscoveryFilter();
@@ -411,4 +419,16 @@ public class SSOConfigurer extends SecurityConfigurerAdapter<Void, ServiceProvid
         this.profileOptions = profileOptions;
         return this;
     }
+
+    /**
+     * Set the {@link SessionAuthenticationStrategy} for the {@link SAMLProcessingFilter}
+     *
+     * @param sessionAuthenticationStrategy to set
+     * @return this configurer for further customization
+     */
+    public SSOConfigurer sessionAuthenticationStrategy(SessionAuthenticationStrategy sessionAuthenticationStrategy) {
+        this.sessionAuthenticationStrategy = sessionAuthenticationStrategy;
+        return this;
+    }
+
 }

--- a/spring-boot-security-saml/src/test/java/com/github/ulisesbocchio/spring/boot/security/saml/configurer/builder/SSOConfigurerTest.java
+++ b/spring-boot-security-saml/src/test/java/com/github/ulisesbocchio/spring/boot/security/saml/configurer/builder/SSOConfigurerTest.java
@@ -16,6 +16,7 @@ import org.springframework.security.saml.SAMLWebSSOHoKProcessingFilter;
 import org.springframework.security.saml.websso.WebSSOProfileOptions;
 import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
 
 import java.util.Collections;
 
@@ -140,6 +141,7 @@ public class SSOConfigurerTest {
         when(configurer.createDefaultSamlEntryPoint()).thenReturn(entryPoint);
         SavedRequestAwareAuthenticationSuccessHandler successHandler = mock(SavedRequestAwareAuthenticationSuccessHandler.class);
         SimpleUrlAuthenticationFailureHandler failureHandler = mock(SimpleUrlAuthenticationFailureHandler.class);
+        SessionAuthenticationStrategy sessionAuthenticationStrategy = mock(SessionAuthenticationStrategy.class);
         WebSSOProfileOptions profileOptions = new WebSSOProfileOptions();
         profileOptions.setAllowCreate(true);
         profileOptions.setAllowedIDPs(Collections.singleton("allowedIdps"));
@@ -167,7 +169,8 @@ public class SSOConfigurerTest {
                 .profileOptions(profileOptions)
                 .ssoHoKProcessingURL("/hok")
                 .ssoLoginURL("/login")
-                .ssoProcessingURL("/sso");
+                .ssoProcessingURL("/sso")
+                .sessionAuthenticationStrategy(sessionAuthenticationStrategy);
         configurer.configure(builder);
 
         verify(properties, never()).getDefaultFailureUrl();
@@ -186,11 +189,13 @@ public class SSOConfigurerTest {
         verify(ssoFilter).setAuthenticationSuccessHandler(eq(successHandler));
         verify(ssoFilter).setAuthenticationFailureHandler(eq(failureHandler));
         verify(ssoFilter).setFilterProcessesUrl(eq("/sso"));
+        verify(ssoFilter).setSessionAuthenticationStrategy(eq(sessionAuthenticationStrategy));
 
         verify(ssoHoKFilter).setAuthenticationManager(eq(authenticationManager));
         verify(ssoHoKFilter).setAuthenticationSuccessHandler(eq(successHandler));
         verify(ssoHoKFilter).setAuthenticationFailureHandler(eq(failureHandler));
         verify(ssoHoKFilter).setFilterProcessesUrl(eq("/hok"));
+        verify(ssoHoKFilter).setSessionAuthenticationStrategy(eq(sessionAuthenticationStrategy));
 
         verify(serviceProviderEndpoints).setSsoProcessingURL("/sso");
         verify(serviceProviderEndpoints).setSsoHoKProcessingURL("/hok");


### PR DESCRIPTION
Add configuring `SessionAuthenticationStrategy` in the `SSOConfigurer` which is passed to the `SAMLProcessingFilter`. This is useful for example defining a `SessionFixationProtectionStrategy` which is used for changing the session id after saml login is done.